### PR TITLE
Update package.json

### DIFF
--- a/package.json
+++ b/package.json
@@ -9,7 +9,7 @@
   "dependencies": {
     "defaults": "^1.0.2",
     "dezalgo": "^1.0.2",
-    "eslint": "git://github.com/eslint/eslint.git#fff52aecaf1d073952201b3f128e6664f529a24e",
+    "eslint": "^0.24.0",
     "find-root": "^0.1.1",
     "get-stdin": "^4.0.1",
     "glob": "^5.0.9",


### PR DESCRIPTION
Here is some history for the pinned dependency: https://github.com/feross/standard/pull/173

`standard` was waiting for `eslint` to update something-or-another, but now that is finished, so we can all move on with our lives with eslint 0.24.0.