### PR TITLE
fix for standard 5

### DIFF
--- a/bin/cmd.js
+++ b/bin/cmd.js
@@ -81,7 +81,7 @@ function Cli (opts) {
   }
 
   var lintOpts = {
-     parser: argv.parser
+    parser: argv.parser
   }
 
   if (argv.stdin) {


### PR DESCRIPTION
standard 5 is stricter about correct indentation in object literals