### PR TITLE
adhere to padded-blocks

### DIFF
--- a/index.js
+++ b/index.js
@@ -110,7 +110,6 @@ Linter.prototype.lintFiles = function (files, opts, cb) {
     }
     return cb(null, result)
   })
-
 }
 
 Linter.prototype.parseOpts = function (opts) {


### PR DESCRIPTION
We are in the process of adding back the rule `padded-blocks` into `standard`. It was temporarily disabled because of a bug in eslint which now has been fixed.

This pull request makes sure that your coding style is compliant with the new version.

Please see feross/standard#170 for more info.