### PR TITLE
Ignore vendored files

### DIFF
--- a/index.js
+++ b/index.js
@@ -22,7 +22,8 @@ var DEFAULT_IGNORE = [
   'coverage/**',
   'node_modules/**',
   '**/*.min.js',
-  '**/bundle.js'
+  '**/bundle.js',
+  'vendor/**'
 ]
 
 function Linter (opts) {


### PR DESCRIPTION
Many projects have vendored files in `vendor/...` that need not to be checked.