### PR TITLE
Fix fetching of eslint with older npm versions

### DIFF
--- a/package.json
+++ b/package.json
@@ -10,7 +10,7 @@
     "defaults": "^1.0.2",
     "deglob": "^1.0.0",
     "dezalgo": "^1.0.2",
-    "eslint": "https://github.com/eslint/eslint.git#9d6223040316456557e0a2383afd96be90d28c5a",
+    "eslint": "git+https://github.com/eslint/eslint.git#9d6223040316456557e0a2383afd96be90d28c5a",
     "find-root": "^0.1.1",
     "get-stdin": "^4.0.1",
     "minimist": "^1.1.0",


### PR DESCRIPTION
Just referencing `https` doesn't work with older versions of npm.

See example where it fails with npm v1.4.6 here: https://travis-ci.org/watson/async-state/builds/81012276

Using the `git+https` scheme instead should fix it.