### PR TITLE
test/clone: fix integerization of parallel limit

### DIFF
--- a/test/clone.js
+++ b/test/clone.js
@@ -29,7 +29,7 @@ var GIT = 'git'
 var STANDARD = path.join(__dirname, 'lib', 'standard-cmd.js')
 var TMP = path.join(__dirname, '..', 'tmp')
 
-var PARALLEL_LIMIT = Math.min(os.cpus().length * 1.5)
+var PARALLEL_LIMIT = Math.floor(os.cpus().length * 1.5)
 
 test('test github repos that use `standard`', function (t) {
   t.plan(testPackages.length)


### PR DESCRIPTION
I'm not sure why `Math.min` is used here (`Math.min(3.5) === 3.5`), I suspect this was meant to be `Math.floor` intead.