### PR TITLE
Initial implementation of caching

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,2 +1,3 @@
 node_modules/
 tmp/
+.standardcache

--- a/README.md
+++ b/README.md
@@ -58,6 +58,8 @@ module.exports = {
   homepage: pkg.homepage,
   bugs: pkg.bugs.url,
   tagline: 'Live by your own standards!', // displayed in output --help
+  cache: false, // set to true for caching
+  cacheFile: '.standardcache', // file to store cache data; implies `cache`
   eslintConfig: {
     configFile: path.join(__dirname, 'eslintrc.json')
   },

--- a/index.js
+++ b/index.js
@@ -95,6 +95,15 @@ Linter.prototype.lintFiles = function (files, opts, cb) {
     configKey: self.cmd
   }
 
+  var eslintConfig = self.eslintConfig
+
+  if (opts.cache || opts.cacheFile) {
+    eslintConfig = extend({}, {
+      cache: true,
+      cacheFile: opts.cacheFile || '.standardcache'
+    }, self.eslintConfig)
+  }
+
   deglob(files, deglobOpts, function (err, allFiles) {
     if (err) return cb(err)
     // undocumented – do not use (used by bin/cmd.js)
@@ -102,7 +111,7 @@ Linter.prototype.lintFiles = function (files, opts, cb) {
 
     var result
     try {
-      result = new eslint.CLIEngine(self.eslintConfig).executeOnFiles(allFiles)
+      result = new eslint.CLIEngine(eslintConfig).executeOnFiles(allFiles)
     } catch (err) {
       return cb(err)
     }

--- a/test/api.js
+++ b/test/api.js
@@ -30,6 +30,15 @@ test('api: lintFiles with caching', function (t) {
   })
 })
 
+test('api: lintFiles without caching', function (t) {
+  t.plan(2)
+  if (getStat('.standardcache')) fs.unlinkSync('.standardcache')
+  standard.lintFiles([], { cwd: 'bin', cache: false }, function (err, result) {
+    t.error(err, 'no error while linting')
+    t.equal(typeof getStat('.standardcache'), 'undefined', '.standardcache was present')
+  })
+})
+
 test('api: lintText', function (t) {
   t.plan(3)
   standard.lintText('console.log("hi there")\n', function (err, result) {

--- a/test/api.js
+++ b/test/api.js
@@ -1,6 +1,7 @@
 var Linter = require('../').linter
 var path = require('path')
 var test = require('tape')
+var fs = require('fs')
 
 // TODO: this test requires clone.js to be run first in order for the eslintrc to exist
 var standard = new Linter({
@@ -19,6 +20,16 @@ test('api: lintFiles', function (t) {
   })
 })
 
+test('api: lintFiles with caching', function (t) {
+  t.plan(2)
+  if (getStat('.standardcache')) fs.unlinkSync('.standardcache')
+  standard.lintFiles([], { cwd: 'bin', cache: true }, function (err, result) {
+    t.error(err, 'no error while linting')
+    t.equal(typeof getStat('.standardcache'), 'object', '.standardcache was not present')
+    if (getStat('.standardcache')) fs.unlinkSync('.standardcache')
+  })
+})
+
 test('api: lintText', function (t) {
   t.plan(3)
   standard.lintText('console.log("hi there")\n', function (err, result) {
@@ -27,3 +38,9 @@ test('api: lintText', function (t) {
     t.equal(result.errorCount, 1, 'should have used single quotes')
   })
 })
+
+function getStat (file) {
+  try {
+    return fs.statSync(file)
+  } catch (e) { }
+}


### PR DESCRIPTION
Sorry about this—see #17. On second thought, this is a good idea.

This means anyone consuming `standard` can programatically be able to turn on caching, without even modifying the `standard` package:

```js
standard = require('standard')
standard.lintFiles(files, { cache: true }, (err, res) => { ... })
```

...whereas before, you need to modify `standard/options.js` to hard-code a `cache` key into it.