### PR TITLE
Don't lint when formatting stdin

### DIFF
--- a/bin/cmd.js
+++ b/bin/cmd.js
@@ -98,7 +98,6 @@ function Cli (opts) {
         text = opts.formatter.transform(text)
         process.stdout.write(text)
       }
-      standard.lintText(text, lintOpts, onResult)
     })
   } else {
     if (argv.format) {


### PR DESCRIPTION
Fixes #22 ( See example problem there)
Change set is pretty straight forward here.
Was there any reason why standard-engine was running lint when formatting stdin?
Also, I didn't see any existing formatting tests; should I add one? How would you like it done?

Thanks