### PR TITLE
lock down eslint to 1.7.3 to fix space-in-parens

### DIFF
--- a/package.json
+++ b/package.json
@@ -10,7 +10,7 @@
     "defaults": "^1.0.2",
     "deglob": "^1.0.0",
     "dezalgo": "^1.0.2",
-    "eslint": "^1.5.0",
+    "eslint": "1.7.3",
     "find-root": "^0.1.1",
     "get-stdin": "^4.0.1",
     "minimist": "^1.1.0",


### PR DESCRIPTION
This is a workaround until https://github.com/eslint/eslint/issues/4302 is fixed.