### PR TITLE
Log warning messages when no errors are present

### DIFF
--- a/bin/cmd.js
+++ b/bin/cmd.js
@@ -114,7 +114,7 @@ function Cli (opts) {
 
   function onResult (err, result) {
     if (err) return onError(err)
-    if (result.errorCount === 0) process.exit(0)
+    if (!result.errorCount && !result.warningCount) process.exit(0)
 
     console.log(
       opts.cmd + ': %s (%s) ',
@@ -132,7 +132,7 @@ function Cli (opts) {
       })
     })
 
-    process.exit(1)
+    process.exit(result.errorCount ? 1 : 0)
   }
 
   function onError (err) {


### PR DESCRIPTION
When eslint rules are configured as a `1`, this will print the warning
message but still exit with code `0`.