### PR TITLE
update eslint to 1.10.3

### DIFF
--- a/package.json
+++ b/package.json
@@ -10,7 +10,7 @@
     "defaults": "^1.0.2",
     "deglob": "^1.0.0",
     "dezalgo": "^1.0.2",
-    "eslint": "1.9.0",
+    "eslint": "^1.10.3",
     "find-root": "^0.1.1",
     "get-stdin": "^4.0.1",
     "minimist": "^1.1.0",


### PR DESCRIPTION
There is still a failing test, but its due to a bug fix in the `block-spacing` rule:

https://github.com/eslint/eslint/issues/4387

Basically, the rule was updated to require spaces for comments in blocks. This seems to affect repos that are doing multiline tricks... so it means they need to pad the comment with spaces:
```diff
 var pkg = join(__dirname, 'test-package')

-var elfJS = function () {/*
+var elfJS = function () { /*
 module.exports = function () {
   console.log("i'm a elf")
 }
-*/}.toString().split('\n').slice(1, -1).join()
+*/ }.toString().split('\n').slice(1, -1).join()
```

There were two projects that were throwing errors:
- `friends-swarm` which I just updated
- `fstream-npm` which we may want to disable in `standard-packages` for now since its failing.

Thoughts on this @feross?

Closes #37 