### PR TITLE
Ignore jspm_packages

### DIFF
--- a/index.js
+++ b/index.js
@@ -18,7 +18,8 @@ var DEFAULT_IGNORE = [
   '**/bundle.js',
   'coverage/**',
   'node_modules/**',
-  'vendor/**'
+  'vendor/**',
+  'jspm_packages/**'
 ]
 
 function Linter (opts) {


### PR DESCRIPTION
There is a request on https://github.com/feross/standard/issues/467.

[jspm](http://jspm.io/) is another package manager, it saves packages downloaded from npm or github to `jspm_packages` folder. It would be nice to add it to the default ignore lists.