### PR TITLE
Do not use .eslintignore files

### DIFF
--- a/index.js
+++ b/index.js
@@ -32,10 +32,11 @@ function Linter (opts) {
   if (!self.eslint) throw new Error('opts.eslint option is required')
 
   self.eslintConfig = defaults(opts.eslintConfig, {
-    useEslintrc: false,
+    envs: [],
     globals: [],
+    ignore: false,
     plugins: [],
-    envs: []
+    useEslintrc: false
   })
   if (!self.eslintConfig) {
     throw new Error('No eslintConfig passed.')


### PR DESCRIPTION
Like .eslintrc files, .eslintignore files should not be used so that
`standard` behaves consistently wherever it is run.

Closes https://github.com/feross/standard/issues/500