### PR TITLE
Support auto-fixing source text (from --stdin and .lintText)

### DIFF
--- a/README.md
+++ b/README.md
@@ -210,7 +210,8 @@ Lint the provided `files` globs. An `opts` object may be provided:
   globals: [],  // global variables to declare
   parser: '',   // custom js parser (e.g. babel-eslint)
   ignore: [],   // file globs to ignore (has sane defaults)
-  cwd: ''       // current working directory (default: process.cwd())
+  cwd: '',      // current working directory (default: process.cwd())
+  fix: false    // automatically fix problems (default: true)
 }
 ```
 

--- a/README.md
+++ b/README.md
@@ -178,7 +178,8 @@ be provided:
 ```js
 {
   globals: [],  // global variables to declare
-  parser: ''    // custom js parser (e.g. babel-eslint)
+  parser: '',   // custom js parser (e.g. babel-eslint)
+  fix: false    // automatically fix problems (default: true)
 }
 ```
 
@@ -193,7 +194,8 @@ The `callback` will be called with an `Error` and `results` object:
         { ruleId: '', message: '', line: 0, column: 0 }
       ],
       errorCount: 0,
-      warningCount: 0
+      warningCount: 0,
+      output: '' // fixed source code (only present with {fix: true} option)
     }
   ],
   errorCount: 0,

--- a/bin/cmd.js
+++ b/bin/cmd.js
@@ -106,7 +106,7 @@ function Cli (opts) {
   }
 
   var lintOpts = {
-    fix: argv.fix,
+    fix: argv.fix, // only has an effect w/ `standard.lintFiles`
     globals: argv.global,
     plugins: argv.plugin,
     envs: argv.env,
@@ -135,10 +135,6 @@ function Cli (opts) {
 
   function onResult (err, result) {
     if (err) return onError(err)
-
-    if (argv.fix && !argv.stdin) {
-      opts.eslint.CLIEngine.outputFixes(result)
-    }
 
     if (!result.errorCount && !result.warningCount) {
       exit(0)

--- a/bin/cmd.js
+++ b/bin/cmd.js
@@ -106,7 +106,7 @@ function Cli (opts) {
   }
 
   var lintOpts = {
-    fix: argv.fix, // only has an effect w/ `standard.lintFiles`
+    fix: argv.fix,
     globals: argv.global,
     plugins: argv.plugin,
     envs: argv.env,
@@ -135,6 +135,10 @@ function Cli (opts) {
 
   function onResult (err, result) {
     if (err) return onError(err)
+
+    if (argv.stdin && argv.fix) {
+      process.stdout.write(result.results[0].output)
+    }
 
     if (!result.errorCount && !result.warningCount) {
       exit(0)
@@ -180,7 +184,7 @@ function Cli (opts) {
    * code is printed to stdout, so print lint errors to stderr in this case.
    */
   function log () {
-    if (argv.stdin && argv.format) {
+    if (argv.stdin && (argv.format || argv.fix)) {
       arguments[0] = opts.cmd + ': ' + arguments[0]
       console.error.apply(console, arguments)
     } else {

--- a/index.js
+++ b/index.js
@@ -76,6 +76,7 @@ Linter.prototype.lintText = function (text, opts, cb) {
  * @param {Object=} opts                  options object
  * @param {Array.<string>=} opts.ignore   file globs to ignore (has sane defaults)
  * @param {string=} opts.cwd              current working directory (default: process.cwd())
+ * @param {boolean=} opts.fix             automatically fix problems
  * @param {Array.<string>=} opts.globals  custom global variables to declare
  * @param {Array.<string>=} opts.plugins  custom eslint plugins
  * @param {Array.<string>=} opts.envs     custom eslint environment
@@ -109,6 +110,11 @@ Linter.prototype.lintFiles = function (files, opts, cb) {
     } catch (err) {
       return cb(err)
     }
+
+    if (opts.fix) {
+      self.eslint.CLIEngine.outputFixes(result)
+    }
+
     return cb(null, result)
   })
 }


### PR DESCRIPTION
Depends on PR: https://github.com/Flet/standard-engine/pull/119

There's no reason to limit this API to just .lintFiles. It works great
with .lintText too.

This actually paves a way for us to get rid of the built-in --format
option entirely, now that --fix works just as well.