### PR TITLE
Remove formatter support (replaced by ESLint --fix)

### DIFF
--- a/README.md
+++ b/README.md
@@ -210,7 +210,8 @@ Lint the provided `files` globs. An `opts` object may be provided:
   globals: [],  // global variables to declare
   parser: '',   // custom js parser (e.g. babel-eslint)
   ignore: [],   // file globs to ignore (has sane defaults)
-  cwd: ''       // current working directory (default: process.cwd())
+  cwd: '',      // current working directory (default: process.cwd())
+  fix: false    // automatically fix problems (default: true)
 }
 ```
 

--- a/README.md
+++ b/README.md
@@ -64,11 +64,7 @@ module.exports = {
   eslintConfig: {
     configFile: path.join(__dirname, 'eslintrc.json')
   },
-  cwd: '', // current working directory, passed to eslint
-
-  // These are optional. If included, the --format option will be made available
-  formatter: require('pocketlint-format'), // note you'll have to create this :)
-  formatterName: 'pocketlint-format'
+  cwd: '' // current working directory, passed to eslint
 }
 ```
 

--- a/README.md
+++ b/README.md
@@ -178,7 +178,8 @@ be provided:
 ```js
 {
   globals: [],  // global variables to declare
-  parser: ''    // custom js parser (e.g. babel-eslint)
+  parser: '',   // custom js parser (e.g. babel-eslint)
+  fix: false    // automatically fix problems (default: true)
 }
 ```
 
@@ -193,7 +194,8 @@ The `callback` will be called with an `Error` and `results` object:
         { ruleId: '', message: '', line: 0, column: 0 }
       ],
       errorCount: 0,
-      warningCount: 0
+      warningCount: 0,
+      output: '' // fixed source code (only present with {fix: true} option)
     }
   ],
   errorCount: 0,

--- a/bin/cmd.js
+++ b/bin/cmd.js
@@ -6,7 +6,6 @@ var defaults = require('defaults')
 var minimist = require('minimist')
 var multiline = require('multiline')
 var getStdin = require('get-stdin')
-var fs = require('fs')
 
 function Cli (opts) {
   var standard = require('../').linter(opts)

--- a/bin/cmd.js
+++ b/bin/cmd.js
@@ -106,7 +106,7 @@ function Cli (opts) {
   }
 
   var lintOpts = {
-    fix: argv.fix,
+    fix: argv.fix, // only has an effect w/ `standard.lintFiles`
     globals: argv.global,
     plugins: argv.plugin,
     envs: argv.env,
@@ -135,10 +135,6 @@ function Cli (opts) {
 
   function onResult (err, result) {
     if (err) return onError(err)
-
-    if (argv.fix && !argv.stdin) {
-      opts.eslint.CLIEngine.outputFixes(result)
-    }
 
     if (!result.errorCount && !result.warningCount) {
       exit(0)

--- a/bin/cmd.js
+++ b/bin/cmd.js
@@ -106,7 +106,7 @@ function Cli (opts) {
   }
 
   var lintOpts = {
-    fix: argv.fix, // only has an effect w/ `standard.lintFiles`
+    fix: argv.fix,
     globals: argv.global,
     plugins: argv.plugin,
     envs: argv.env,
@@ -135,6 +135,10 @@ function Cli (opts) {
 
   function onResult (err, result) {
     if (err) return onError(err)
+
+    if (argv.stdin && argv.fix) {
+      process.stdout.write(result.results[0].output)
+    }
 
     if (!result.errorCount && !result.warningCount) {
       exit(0)
@@ -180,7 +184,7 @@ function Cli (opts) {
    * code is printed to stdout, so print lint errors to stderr in this case.
    */
   function log () {
-    if (argv.stdin && argv.format) {
+    if (argv.stdin && (argv.format || argv.fix)) {
       arguments[0] = opts.cmd + ': ' + arguments[0]
       console.error.apply(console, arguments)
     } else {

--- a/bin/cmd.js
+++ b/bin/cmd.js
@@ -74,13 +74,13 @@ function Cli (opts) {
                 --parser    Use custom js parser (e.g. babel-eslint)
       */
     }), opts.cmd)
-    exit(0)
+    process.exitCode = 0
     return
   }
 
   if (argv.version) {
     console.log(opts.version)
-    exit(0)
+    process.exitCode = 0
     return
   }
 
@@ -108,7 +108,7 @@ function Cli (opts) {
     }
 
     if (!result.errorCount && !result.warningCount) {
-      exit(0)
+      process.exitCode = 0
       return
     }
 
@@ -130,7 +130,7 @@ function Cli (opts) {
       })
     })
 
-    exit(result.errorCount ? 1 : 0)
+    process.exitCode = result.errorCount ? 1 : 0
     return
   }
 
@@ -141,7 +141,7 @@ function Cli (opts) {
       '\nIf you think this is a bug in `%s`, open an issue: %s',
       opts.cmd, opts.bugs
     )
-    exit(1)
+    process.exitCode = 1
     return
   }
 
@@ -157,17 +157,5 @@ function Cli (opts) {
     } else {
       console.log.apply(console, arguments)
     }
-  }
-}
-
-function exit (code) {
-  if (/^v0.10./.test(process.version)) {
-    // Node v0.10.x lacks support for `process.exitCode`
-    process.exit(code)
-  } else {
-    // Node v6.x will truncate stdout if process.exit(code) is called, so we set
-    // process.exitCode and wait for Node to quit when there's nothing left in
-    // the event loop
-    process.exitCode = code
   }
 }

--- a/index.js
+++ b/index.js
@@ -101,8 +101,6 @@ Linter.prototype.lintFiles = function (files, opts, cb) {
 
   deglob(files, deglobOpts, function (err, allFiles) {
     if (err) return cb(err)
-    // undocumented – do not use (used by bin/cmd.js)
-    if (opts._onFiles) opts._onFiles(allFiles)
 
     var result
     try {

--- a/index.js
+++ b/index.js
@@ -76,6 +76,7 @@ Linter.prototype.lintText = function (text, opts, cb) {
  * @param {Object=} opts                  options object
  * @param {Array.<string>=} opts.ignore   file globs to ignore (has sane defaults)
  * @param {string=} opts.cwd              current working directory (default: process.cwd())
+ * @param {boolean=} opts.fix             automatically fix problems
  * @param {Array.<string>=} opts.globals  custom global variables to declare
  * @param {Array.<string>=} opts.plugins  custom eslint plugins
  * @param {Array.<string>=} opts.envs     custom eslint environment
@@ -109,6 +110,11 @@ Linter.prototype.lintFiles = function (files, opts, cb) {
     } catch (err) {
       return cb(err)
     }
+
+    if (opts.fix) {
+      self.eslint.CLIEngine.outputFixes(result)
+    }
+
     return cb(null, result)
   })
 }

--- a/test/clone.js
+++ b/test/clone.js
@@ -73,7 +73,7 @@ test('test github repos that use `standard`', function (t) {
     var url = pkg.repo + '.git'
     var folder = path.join(TMP, name)
     return function (cb) {
-      access(path.join(TMP, name), fs.R_OK | fs.W_OK, function (err) {
+      fs.access(path.join(TMP, name), fs.R_OK | fs.W_OK, function (err) {
         if (argv.offline) {
           if (err) {
             t.pass('SKIPPING (offline): ' + name + ' (' + pkg.repo + ')')
@@ -134,17 +134,4 @@ function spawn (command, args, opts, cb) {
     cb(null)
   })
   return child
-}
-
-function access (path, mode, callback) {
-  if (typeof mode === 'function') {
-    return access(path, null, callback)
-  }
-
-  // Node v0.10 lacks `fs.access`, which is faster, so fallback to `fs.stat`
-  if (typeof fs.access === 'function') {
-    fs.access(path, mode, callback)
-  } else {
-    fs.stat(path, callback)
-  }
 }


### PR DESCRIPTION
Depends on https://github.com/Flet/standard-engine/pull/119 and https://github.com/Flet/standard-engine/pull/120

`standard --fix` uses ESLint's built-in formatting functionality. The
nice thing about this vs. a formatter based on esformatter is that it
doesn't require maintaining a whole separate config file for a
different tool. It comes for free from the existing list of ESLint
rules. It also appears to be a lot more reliable than esformatter, with
ES6 support that's as good as ESLint's.

The esformatter integration was some of the trickiest code in this
package. I'm happy to finally be able to remove it.

This should be released as a new major version.