### PR TITLE
Remove unneeded `xtend` and `defaults` dependencies

### DIFF
--- a/bin/cmd.js
+++ b/bin/cmd.js
@@ -2,18 +2,17 @@
 
 module.exports = Cli
 
-var defaults = require('defaults')
 var minimist = require('minimist')
 var getStdin = require('get-stdin')
 
 function Cli (opts) {
   var standard = require('../').linter(opts)
 
-  opts = defaults(opts, {
+  opts = Object.assign({
     cmd: 'standard-engine',
     tagline: 'JavaScript Custom Style',
     version: require('../package.json').version
-  })
+  }, opts)
 
   var argv = minimist(process.argv.slice(2), {
     alias: {

--- a/index.js
+++ b/index.js
@@ -2,9 +2,7 @@ module.exports.cli = require('./bin/cmd')
 
 module.exports.linter = Linter
 
-var defaults = require('defaults')
 var deglob = require('deglob')
-var extend = require('xtend')
 var findRoot = require('find-root')
 var pkgConfig = require('pkg-config')
 
@@ -31,17 +29,14 @@ function Linter (opts) {
   self.cwd = opts.cwd
   if (!self.eslint) throw new Error('opts.eslint option is required')
 
-  self.eslintConfig = defaults(opts.eslintConfig, {
+  self.eslintConfig = Object.assign({
     envs: [],
     fix: false,
     globals: [],
     ignore: false,
     plugins: [],
     useEslintrc: false
-  })
-  if (!self.eslintConfig) {
-    throw new Error('No eslintConfig passed.')
-  }
+  }, opts.eslintConfig)
 }
 
 /**
@@ -121,8 +116,8 @@ Linter.prototype.parseOpts = function (opts) {
   var self = this
 
   if (!opts) opts = {}
-  opts = extend(opts)
-  opts.eslintConfig = extend(self.eslintConfig)
+  opts = Object.assign({}, opts)
+  opts.eslintConfig = Object.assign({}, self.eslintConfig)
 
   if (!opts.cwd) opts.cwd = self.cwd || process.cwd()
 

--- a/package.json
+++ b/package.json
@@ -7,13 +7,11 @@
     "url": "https://github.com/flet/standard-engine/issues"
   },
   "dependencies": {
-    "defaults": "^1.0.2",
     "deglob": "^1.0.0",
     "find-root": "^1.0.0",
     "get-stdin": "^5.0.1",
     "minimist": "^1.1.0",
-    "pkg-config": "^1.0.1",
-    "xtend": "^4.0.0"
+    "pkg-config": "^1.0.1"
   },
   "devDependencies": {
     "babel-eslint": "^6.0.1",

--- a/package.json
+++ b/package.json
@@ -7,7 +7,7 @@
     "url": "https://github.com/flet/standard-engine/issues"
   },
   "dependencies": {
-    "deglob": "^1.0.0",
+    "deglob": "^2.0.0",
     "find-root": "^1.0.0",
     "get-stdin": "^5.0.1",
     "minimist": "^1.1.0",


### PR DESCRIPTION
These are not required in Node v4 anymore!

This removes a total of 3 modules from the tree.

Inspired by @nolanlawson's tweet:
https://twitter.com/nolanlawson/status/766275330403205122