### PR TITLE
Add ESLint `cache` option

### DIFF
--- a/index.js
+++ b/index.js
@@ -4,6 +4,8 @@ module.exports.linter = Linter
 
 var deglob = require('deglob')
 var findRoot = require('find-root')
+var homeOrTmp = require('home-or-tmp')
+var path = require('path')
 var pkgConfig = require('pkg-config')
 
 var DEFAULT_PATTERNS = [
@@ -30,6 +32,8 @@ function Linter (opts) {
   if (!self.eslint) throw new Error('opts.eslint option is required')
 
   self.eslintConfig = Object.assign({
+    cache: true,
+    cacheLocation: path.join(homeOrTmp, '.standard-cache/'),
     envs: [],
     fix: false,
     globals: [],

--- a/package.json
+++ b/package.json
@@ -10,6 +10,7 @@
     "deglob": "^2.0.0",
     "find-root": "^1.0.0",
     "get-stdin": "^5.0.1",
+    "home-or-tmp": "^2.0.0",
     "minimist": "^1.1.0",
     "pkg-config": "^1.0.1"
   },

--- a/package.json
+++ b/package.json
@@ -19,7 +19,7 @@
     "cross-spawn": "^4.0.0",
     "eslint": "^3.0.1",
     "eslint-config-standard": "^6.0.0-beta.0",
-    "eslint-config-standard-jsx": "^2.0.0",
+    "eslint-config-standard-jsx": "^3.0.0",
     "eslint-plugin-promise": "^2.0.0",
     "eslint-plugin-react": "^6.0.0",
     "eslint-plugin-standard": "^2.0.0",


### PR DESCRIPTION
Running `standard` on a large codebase like [electron/electron](https://github.com/electron/electron) is now more than 2x faster on repeated runs, thanks to the ESLint cache feature!

- Before: 3.68s
- After: 1.59s

Fixes: https://github.com/feross/standard/issues/277

(I copied this code from the xo project.)