### PR TITLE
Support parseOpts() option

### DIFF
--- a/README.md
+++ b/README.md
@@ -68,6 +68,8 @@ module.exports = {
 }
 ```
 
+Additionally an optional `parseOpts()` function can be provided. See below for details.
+
 **eslintrc.json**
  Put all your .eslintrc rules in this file. A good practice is to create an  [ESLint Shareable Config](http://eslint.org/docs/developer-guide/shareable-configs) and extend it, but its not required:
 ```js
@@ -199,6 +201,44 @@ You may use `env` as an alias for `envs` (just don't specify both).
 
 If you're using your custom linter globally (you installed it with `-g`), then you also need to
 install `babel-eslint` globally with `npm install babel-eslint -g`.
+
+### Custom options
+
+You can provide a `parseOpts()` function in the `options.js` exports:
+
+```js
+var eslint = require('eslint')
+var path = require('path')
+var pkg = require('./package.json')
+
+module.exports = {
+  // homepage, version and bugs pulled from package.json
+  version: pkg.version,
+  homepage: pkg.homepage,
+  bugs: pkg.bugs.url,
+  eslint: eslint, // pass any version of eslint >= 1.0.0
+  cmd: 'pocketlint', // should match the "bin" key in your package.json
+  tagline: 'Live by your own standards!', // displayed in output --help
+  eslintConfig: {
+    configFile: path.join(__dirname, 'eslintrc.json')
+  },
+  parseOpts (opts, packageOpts, rootDir) {
+    // provide implementation here, then return the opts object (or a new one)
+    return opts
+  }
+}
+```
+
+This function is called with the current options object (`opts`), any options extracted from the project's `package.json` (`packageOpts`), and the directory that contained that `package.json` file (`rootDir`, equivalent to `opts.cwd` if no file was found).
+
+Modify and return `opts`, or return a new object with the options that are to be used.
+
+The following options are provided in the `opts` object, and must be on the returned object:
+
+* `ignore`: array of file globs to ignore
+* `cwd`: string, the current working directory
+* `fix`: boolean, whether to automatically fix problems
+* `eslintConfig`: object, the options passed to [ESLint's `CLIEngine`](http://eslint.org/docs/developer-guide/nodejs-api#cliengine)
 
 ## API Usage
 

--- a/index.js
+++ b/index.js
@@ -3,10 +3,9 @@ module.exports.cli = require('./bin/cmd')
 module.exports.linter = Linter
 
 var deglob = require('deglob')
-var findRoot = require('find-root')
 var homeOrTmp = require('home-or-tmp')
 var path = require('path')
-var pkgConfig = require('pkg-config')
+var pkgConf = require('pkg-conf')
 
 var DEFAULT_PATTERNS = [
   '**/*.js',
@@ -135,19 +134,12 @@ Linter.prototype.parseOpts = function (opts) {
   setEnvs(opts.envs || opts.env)
   setParser(opts.parser)
 
-  var root
-  try { root = findRoot(opts.cwd) } catch (e) {}
-  if (root) {
-    var packageOpts = pkgConfig(self.cmd, { root: false, cwd: opts.cwd })
-
-    if (packageOpts) {
-      setIgnore(packageOpts.ignore)
-      setGlobals(packageOpts.globals || packageOpts.global)
-      setPlugins(packageOpts.plugins || packageOpts.plugin)
-      setEnvs(packageOpts.envs || packageOpts.env)
-      if (!opts.parser) setParser(packageOpts.parser)
-    }
-  }
+  var packageOpts = pkgConf.sync(self.cmd, { cwd: opts.cwd })
+  setIgnore(packageOpts.ignore)
+  setGlobals(packageOpts.globals || packageOpts.global)
+  setPlugins(packageOpts.plugins || packageOpts.plugin)
+  setEnvs(packageOpts.envs || packageOpts.env)
+  if (!opts.parser) setParser(packageOpts.parser)
 
   function setIgnore (ignore) {
     if (!ignore) return

--- a/index.js
+++ b/index.js
@@ -29,6 +29,7 @@ function Linter (opts) {
   self.eslint = opts.eslint
   self.cwd = opts.cwd
   if (!self.eslint) throw new Error('opts.eslint option is required')
+  self.customParseOpts = opts.parseOpts
 
   self.eslintConfig = Object.assign({
     cache: true,
@@ -140,6 +141,12 @@ Linter.prototype.parseOpts = function (opts) {
   setPlugins(packageOpts.plugins || packageOpts.plugin)
   setEnvs(packageOpts.envs || packageOpts.env)
   if (!opts.parser) setParser(packageOpts.parser)
+
+  if (self.customParseOpts) {
+    var filepath = pkgConf.filepath(packageOpts)
+    var rootDir = filepath ? path.dirname(filepath) : opts.cwd
+    opts = self.customParseOpts(opts, packageOpts, rootDir)
+  }
 
   function setIgnore (ignore) {
     if (!ignore) return

--- a/package.json
+++ b/package.json
@@ -8,11 +8,10 @@
   },
   "dependencies": {
     "deglob": "^2.1.0",
-    "find-root": "^1.0.0",
     "get-stdin": "^5.0.1",
     "home-or-tmp": "^2.0.0",
     "minimist": "^1.1.0",
-    "pkg-config": "^1.0.1"
+    "pkg-conf": "^2.0.0"
   },
   "devDependencies": {
     "babel-eslint": "^7.1.1",


### PR DESCRIPTION
This replaces find-root and pkg-config by pkg-conf.

pkg-conf can find config without throwing exceptions. It returns an
empty object by default, simplifying logic. And, usefully, it lets you
determine the path of the loaded `package.json` file.

pkg-config caches the JSON, though not the file resolution. I doubt the
caching has any measurable impact when it comes to `standard-engine` and
its use. Caching could be implemented on top of pkg-conf if necessary
though.

Adds support for a `parseOpts()` option in `options.js`. Fixes #132.