### PR TITLE
wip! Resolve ignore options in standard-engine, not deglob

### DIFF
--- a/index.js
+++ b/index.js
@@ -95,8 +95,7 @@ Linter.prototype.lintFiles = function (files, opts, cb) {
     ignore: opts.ignore,
     cwd: opts.cwd,
     useGitIgnore: true,
-    usePackageJson: true,
-    configKey: self.cmd
+    usePackageJson: false
   }
 
   deglob(files, deglobOpts, function (err, allFiles) {
@@ -142,11 +141,17 @@ Linter.prototype.parseOpts = function (opts) {
     var packageOpts = pkgConfig(self.cmd, { root: false, cwd: opts.cwd })
 
     if (packageOpts) {
+      setIgnore(packageOpts.ignore)
       setGlobals(packageOpts.globals || packageOpts.global)
       setPlugins(packageOpts.plugins || packageOpts.plugin)
       setEnvs(packageOpts.envs || packageOpts.env)
       if (!opts.parser) setParser(packageOpts.parser)
     }
+  }
+
+  function setIgnore (ignore) {
+    if (!ignore) return
+    opts.ignore = opts.ignore.concat(ignore)
   }
 
   function setGlobals (globals) {


### PR DESCRIPTION
`standard-engine` has all the information it needs to resolve these
options. `deglob` shouldn't have to repeat the work of finding the
`package.json`.

This will make it easier to control the `ignore` globs in a custom
options parser, for which see
<https://github.com/Flet/standard-engine/pull/135>.

Requires https://github.com/Flet/deglob/pull/6 to be released and the
minimum version to be bumped.