### PR TITLE
Make formatter configurable

### DIFF
--- a/README.md
+++ b/README.md
@@ -64,9 +64,12 @@ module.exports = {
   eslintConfig: {
     configFile: path.join(__dirname, 'eslintrc.json')
   },
-  cwd: '' // current working directory, passed to eslint
+  cwd: '', // current working directory, passed to eslint
+  formatter: '' // formatter for errors and warnings
 }
 ```
+
+By default `standard-engine`'s formatter is used. Alternatively provide one of ESLint's [built-in formatters](http://eslint.org/docs/developer-guide/nodejs-api#getformatter), an absolute path to a custom formatter (for example `require.resolve('my-custom-formatter-module')`) or a formatter function.
 
 **eslintrc.json**
  Put all your .eslintrc rules in this file. A good practice is to create an  [ESLint Shareable Config](http://eslint.org/docs/developer-guide/shareable-configs) and extend it, but its not required:

--- a/lib/formatter.js
+++ b/lib/formatter.js
@@ -1,0 +1,16 @@
+module.exports = makeFormatter
+
+function makeFormatter (opts, argv) {
+  return function (results) {
+    var prefix = argv.stdin && argv.fix ? `${opts.cmd}: ` : ''
+
+    return results.reduce(function (lines, result) {
+      result.messages.forEach(function (message) {
+        var postfix = argv.verbose ? ` (${message.ruleId})` : ''
+        lines.push(`${prefix}  ${result.filePath}:${message.line || 0}:${message.column || 0}: ${message.message}${postfix}`)
+      })
+
+      return lines
+    }, []).join('\n')
+  }
+}

--- a/package.json
+++ b/package.json
@@ -6,6 +6,10 @@
   "bugs": {
     "url": "https://github.com/flet/standard-engine/issues"
   },
+  "files": [
+    "index.js",
+    "bin"
+  ],
   "dependencies": {
     "deglob": "^2.0.0",
     "find-root": "^1.0.0",

--- a/package.json
+++ b/package.json
@@ -8,7 +8,8 @@
   },
   "files": [
     "index.js",
-    "bin"
+    "bin",
+    "lib"
   ],
   "dependencies": {
     "deglob": "^2.0.0",


### PR DESCRIPTION
First commit sneaks in a `files` declaration in `package.json`. I can do that in a separate PR or remove it all together if necessary.

This makes the formatter configurable as per https://github.com/Flet/standard-engine/issues/133#issuecomment-257358089. I've opted to only make it configurable via `options.js`. This means the `standard-engine` implementation has full control, and editor plugins or users cannot modify it. We can change that in this PR or as follow-up.

Fixes #133.