### PR TITLE
Configure files in package.json

### DIFF
--- a/package.json
+++ b/package.json
@@ -6,6 +6,10 @@
   "bugs": {
     "url": "https://github.com/flet/standard-engine/issues"
   },
+  "files": [
+    "index.js",
+    "bin"
+  ],
   "dependencies": {
     "deglob": "^2.1.0",
     "find-root": "^1.0.0",


### PR DESCRIPTION
Minimizes which files are published to npm.

Before:

```
package.json
.npmignore
README.md
LICENSE
index.js
bin/cmd.js
.travis.yml
test/api.js
test/clone.js
test/lib/standard-cmd.js
test/lib/standard.json
CHANGELOG.md
```

After:

```
package.json
README.md
LICENSE
index.js
bin/cmd.js
CHANGELOG.md
```