### PR TITLE
Stop package.json settings from overriding explicit options

### DIFF
--- a/README.md
+++ b/README.md
@@ -292,4 +292,4 @@ The following aliases are available:
 
 Note that `globals`, `plugins` and `envs` take preference.
 
-The `parser` option takes preference over any `parser` setting in the project's `package.json`.
+When `globals`, `plugins`, `envs` and `parser` options (and their aliases) are provided to the above APIs, the corresponding settings in the project's `package.json` are ignored. Use a custom `parseOpts()` function to merge the settings as needed.

--- a/index.js
+++ b/index.js
@@ -130,10 +130,12 @@ Linter.prototype.parseOpts = function (opts) {
 
   if (opts.fix != null) opts.eslintConfig.fix = opts.fix
 
-  setGlobals(opts.globals || opts.global)
-  setPlugins(opts.plugins || opts.plugin)
-  setEnvs(opts.envs || opts.env)
-  setParser(opts.parser)
+  var preventOverride = {}
+
+  preventOverride.globals = setGlobals(opts.globals || opts.global)
+  preventOverride.plugins = setPlugins(opts.plugins || opts.plugin)
+  preventOverride.envs = setEnvs(opts.envs || opts.env)
+  preventOverride.parser = setParser(opts.parser)
 
   var root
   try { root = findRoot(opts.cwd) } catch (e) {}
@@ -142,10 +144,10 @@ Linter.prototype.parseOpts = function (opts) {
 
     if (packageOpts) {
       setIgnore(packageOpts.ignore)
-      setGlobals(packageOpts.globals || packageOpts.global)
-      setPlugins(packageOpts.plugins || packageOpts.plugin)
-      setEnvs(packageOpts.envs || packageOpts.env)
-      if (!opts.parser) setParser(packageOpts.parser)
+      if (!preventOverride.globals) setGlobals(packageOpts.globals || packageOpts.global)
+      if (!preventOverride.plugins) setPlugins(packageOpts.plugins || packageOpts.plugin)
+      if (!preventOverride.envs) setEnvs(packageOpts.envs || packageOpts.env)
+      if (!preventOverride.parser) setParser(packageOpts.parser)
     }
   }
 
@@ -155,27 +157,31 @@ Linter.prototype.parseOpts = function (opts) {
   }
 
   function setGlobals (globals) {
-    if (!globals) return
+    if (!globals) return false
     opts.eslintConfig.globals = self.eslintConfig.globals.concat(globals)
+    return true
   }
 
   function setPlugins (plugins) {
-    if (!plugins) return
+    if (!plugins) return false
     opts.eslintConfig.plugins = self.eslintConfig.plugins.concat(plugins)
+    return true
   }
 
   function setEnvs (envs) {
-    if (!envs) return
+    if (!envs) return false
     if (!Array.isArray(envs) && typeof envs !== 'string') {
       // envs can be an object in `package.json`
       envs = Object.keys(envs).filter(function (env) { return envs[env] })
     }
     opts.eslintConfig.envs = self.eslintConfig.envs.concat(envs)
+    return true
   }
 
   function setParser (parser) {
-    if (!parser) return
+    if (!parser) return false
     opts.eslintConfig.parser = parser
+    return true
   }
 
   return opts


### PR DESCRIPTION
Fixes #141.

This would be a **breaking change**. Contrary to https://github.com/Flet/standard-engine/pull/134#discussion_r85782733 though I'm only now (after writing the code) noticing that `globals`, `plugins` and `envs` are *concatenated* onto the existing values. So perhaps this **isn't** a problem at all?

If this is merged after all, note that I'm assuming #135 has landed, since it would allow implementors to write their own option merging logic.