### PR TITLE
Do not ignore node_modules

### DIFF
--- a/index.js
+++ b/index.js
@@ -17,7 +17,6 @@ var DEFAULT_IGNORE = [
   '**/*.min.js',
   '**/bundle.js',
   'coverage/**',
-  'node_modules/**',
   'vendor/**'
 ]
 


### PR DESCRIPTION
Because ESLint does this by default
http://eslint.org/docs/user-guide/configuring#ignoring-files-and-directories