### PR TITLE
fix comments

### DIFF
--- a/README.md
+++ b/README.md
@@ -251,7 +251,7 @@ be provided:
 ```js
 {
   cwd: '',      // current working directory (default: process.cwd())
-  filename: '', // path of the file containing the text being linted (optional)
+  filename: '', // path of the file containing the text being linted, you should specify it when running `lintText` with eslint plugins
   fix: false,   // automatically fix problems
   globals: [],  // custom global variables to declare
   plugins: [],  // custom eslint plugins

--- a/index.js
+++ b/index.js
@@ -53,6 +53,7 @@ function Linter (opts) {
  * @param {Array.<string>=} opts.plugins  custom eslint plugins
  * @param {Array.<string>=} opts.envs     custom eslint environment
  * @param {string=} opts.parser           custom js parser (e.g. babel-eslint)
+ * @param {string=} opts.filename         path of the file containing the text being linted
  * @param {function(Error, Object)} cb    callback
  */
 Linter.prototype.lintText = function (text, opts, cb) {


### PR DESCRIPTION
When we run `lintText` with `eslint-plugin-html` plugin, `opts.filename` should be specified or we will get wrong results.

## Example:

**index.js**:

```node
var standard = require('standard')
var fs = require('fs')
fs.readFile('./index.html', 'utf8', function (err, html) {
  standard.lintText(html, {
    plugins: ['html'],
    filename: 'index.html'
  }, function (err, result) {
    console.log(result.results[0])
  })

  standard.lintText(html, {
    plugins: ['html']
  }, function (err, result) {
    console.log(result.results[0])
  })
})

```

**index.html**:

```html
<html><head><title>haha</title></head><body>
<script>
var a= 1;
</script>
</body></html>

```

And the console:

```
{ filePath: '/Users/sam/Documents/tmp/test-eslint/index.html',
  messages: 
   [ { ruleId: 'no-unused-vars',
       severity: 2,
       message: '\'a\' is assigned a value but never used.',
       line: 3,
       column: 5,
       nodeType: 'Identifier',
       source: 'var a= 1;' },
     { ruleId: 'space-infix-ops',
       severity: 2,
       message: 'Infix operators must be spaced.',
       line: 3,
       column: 6,
       nodeType: 'VariableDeclarator',
       source: 'var a= 1;',
       fix: [Object] },
     { ruleId: 'semi',
       severity: 2,
       message: 'Extra semicolon.',
       line: 3,
       column: 9,
       nodeType: 'VariableDeclaration',
       source: 'var a= 1;',
       fix: [Object] } ],
  errorCount: 3,
  warningCount: 0,
  source: '<html><head><title>haha</title></head><body>\n<script>\nvar a= 1;\n</script>\n</body></html>\n' }
{ filePath: '<text>',
  messages: 
   [ { ruleId: 'react/jsx-indent',
       severity: 2,
       message: 'Expected indentation of 2 space characters but found 0.',
       line: 2,
       column: 1,
       nodeType: 'JSXOpeningElement',
       source: '<script>',
       fix: [Object] } ],
  errorCount: 1,
  warningCount: 0,
  source: '<html><head><title>haha</title></head><body>\n<script>\nvar a= 1;\n</script>\n</body></html>\n' }
```