### PR TITLE
BREAKING: make lintText into a sync method

### DIFF
--- a/README.md
+++ b/README.md
@@ -243,7 +243,7 @@ The following options are provided in the `opts` object, and must be on the retu
 
 ## API Usage
 
-### `standardEngine.lintText(text, [opts], callback)`
+### `results = standardEngine.lintText(text, [opts])`
 
 Lint the provided source `text` to enforce your defined style. An `opts` object may
 be provided:
@@ -262,7 +262,7 @@ be provided:
 
 Additional options may be loaded from a `package.json` if it's found for the current working directory. See below for further details.
 
-The `callback` will be called with an `Error` and `results` object:
+If an error occurs, an exception is thrown. Otherwise, a `results` object is returned:
 
 ```js
 {

--- a/bin/cmd.js
+++ b/bin/cmd.js
@@ -93,7 +93,13 @@ Flags (advanced):
   if (argv.stdin) {
     getStdin().then(function (text) {
       stdinText = text
-      standard.lintText(text, lintOpts, onResult)
+      var result
+      try {
+        result = standard.lintText(text, lintOpts)
+      } catch (err) {
+        return onResult(err)
+      }
+      onResult(null, result)
     })
   } else {
     standard.lintFiles(argv._, lintOpts, onResult)

--- a/index.js
+++ b/index.js
@@ -21,17 +21,16 @@ var DEFAULT_IGNORE = [
 ]
 
 function Linter (opts) {
-  var self = this
-  if (!(self instanceof Linter)) return new Linter(opts)
+  if (!(this instanceof Linter)) return new Linter(opts)
   if (!opts) opts = {}
 
-  self.cmd = opts.cmd || 'standard'
-  self.eslint = opts.eslint
-  self.cwd = opts.cwd
-  if (!self.eslint) throw new Error('opts.eslint option is required')
-  self.customParseOpts = opts.parseOpts
+  this.cmd = opts.cmd || 'standard'
+  this.eslint = opts.eslint
+  this.cwd = opts.cwd
+  if (!this.eslint) throw new Error('opts.eslint option is required')
+  this.customParseOpts = opts.parseOpts
 
-  self.eslintConfig = Object.assign({
+  this.eslintConfig = Object.assign({
     cache: true,
     cacheLocation: path.join(homeOrTmp, '.standard-cache/'),
     envs: [],
@@ -54,20 +53,10 @@ function Linter (opts) {
  * @param {Array.<string>=} opts.envs     custom eslint environment
  * @param {string=} opts.parser           custom js parser (e.g. babel-eslint)
  * @param {string=} opts.filename         path of the file containing the text being linted
- * @param {function(Error, Object)} cb    callback
  */
-Linter.prototype.lintText = function (text, opts, cb) {
-  var self = this
-  if (typeof opts === 'function') return self.lintText(text, null, opts)
-  opts = self.parseOpts(opts)
-
-  var result
-  try {
-    result = new self.eslint.CLIEngine(opts.eslintConfig).executeOnText(text, opts.filename)
-  } catch (err) {
-    return nextTick(cb, err)
-  }
-  return nextTick(cb, null, result)
+Linter.prototype.lintText = function (text, opts) {
+  opts = this.parseOpts(opts)
+  return new this.eslint.CLIEngine(opts.eslintConfig).executeOnText(text, opts.filename)
 }
 
 /**
@@ -179,10 +168,4 @@ Linter.prototype.parseOpts = function (opts) {
   }
 
   return opts
-}
-
-function nextTick (cb, err, val) {
-  process.nextTick(function () {
-    cb(err, val)
-  })
 }

--- a/test/api.js
+++ b/test/api.js
@@ -20,13 +20,11 @@ test('api: lintFiles', function (t) {
 })
 
 test('api: lintText', function (t) {
-  t.plan(3)
+  t.plan(2)
   var standard = getStandard()
-  standard.lintText('console.log("hi there")\n', function (err, result) {
-    t.error(err, 'no error while linting')
-    t.equal(typeof result, 'object', 'result is an object')
-    t.equal(result.errorCount, 1, 'should have used single quotes')
-  })
+  var result = standard.lintText('console.log("hi there")\n')
+  t.equal(typeof result, 'object', 'result is an object')
+  t.equal(result.errorCount, 1, 'should have used single quotes')
 })
 
 test('api: parseOpts -- avoid self.eslintConfig parser mutation', function (t) {


### PR DESCRIPTION
Fixes: https://github.com/Flet/standard-engine/issues/156

Before: `standardEngine.lintText(text, [opts], callback)`
After: `results = standardEngine.lintText(text, [opts])`

If an error occurs, an exception is thrown. Otherwise, a `results`
object is returned.