### PR TITLE
BREAKING: rename the syncronous `lintText` method to `lintTextSync`

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,19 @@
 All notable changes to this project will be documented in this file.
 This project adheres to [Semantic Versioning](http://semver.org/).
 
+## 7.0.0 - 2017-04-04
+
+- BREAKING: rename the syncronous `lintText` method to `lintTextSync`
+- Add an asyncronous `lintText` method (that just calls `lintTextSync` internally)
+
+This effectively undoes the breaking change introduced in 6.0.0, making it safe to
+upgrade from `standard-engine` 5.x to 7.x without introducing any breaking changes.
+
+Related issues:
+
+- https://github.com/feross/standard/issues/807
+- https://github.com/Flet/standard-engine/issues/156
+
 ## 6.0.0 - 2017-02-20
 
 - BREAKING: make `lintText` into a sync method

--- a/README.md
+++ b/README.md
@@ -242,7 +242,7 @@ The following options are provided in the `opts` object, and must be on the retu
 
 ## API Usage
 
-### `results = standardEngine.lintText(text, [opts])`
+### `engine.lintText(text, [opts], callback)`
 
 Lint the provided source `text` to enforce your defined style. An `opts` object may
 be provided:
@@ -261,7 +261,9 @@ be provided:
 
 Additional options may be loaded from a `package.json` if it's found for the current working directory. See below for further details.
 
-If an error occurs, an exception is thrown. Otherwise, a `results` object is returned:
+The `callback` will be called with an `Error` and `results` object.
+
+The `results` object will contain the following properties:
 
 ```js
 {
@@ -281,7 +283,12 @@ If an error occurs, an exception is thrown. Otherwise, a `results` object is ret
 }
 ```
 
-### `standardEngine.lintFiles(files, [opts], callback)`
+### `results = engine.lintTextSync(text, [opts])`
+
+Synchronous version of `engine.lintText()`. If an error occurs, an exception is
+thrown. Otherwise, a `results` object is returned.
+
+### `engine.lintFiles(files, [opts], callback)`
 
 Lint the provided `files` globs. An `opts` object may be provided:
 
@@ -302,6 +309,8 @@ Additional options may be loaded from a `package.json` if it's found for the cur
 Both `ignore` and `files` globs are resolved relative to the current working directory.
 
 The `callback` will be called with an `Error` and `results` object (same as above).
+
+**NOTE: There is no synchronous version of `engine.lintFiles()`.**
 
 ### Full set of `opts`
 

--- a/bin/cmd.js
+++ b/bin/cmd.js
@@ -93,13 +93,7 @@ Flags (advanced):
   if (argv.stdin) {
     getStdin().then(function (text) {
       stdinText = text
-      var result
-      try {
-        result = standard.lintText(text, lintOpts)
-      } catch (err) {
-        return onResult(err)
-      }
-      onResult(null, result)
+      standard.lintText(text, lintOpts, onResult)
     })
   } else {
     standard.lintFiles(argv._, lintOpts, onResult)

--- a/index.js
+++ b/index.js
@@ -54,9 +54,20 @@ function Linter (opts) {
  * @param {string=} opts.parser           custom js parser (e.g. babel-eslint)
  * @param {string=} opts.filename         path of the file containing the text being linted
  */
-Linter.prototype.lintText = function (text, opts) {
+Linter.prototype.lintTextSync = function (text, opts) {
   opts = this.parseOpts(opts)
   return new this.eslint.CLIEngine(opts.eslintConfig).executeOnText(text, opts.filename)
+}
+
+Linter.prototype.lintText = function (text, opts, cb) {
+  if (typeof opts === 'function') return this.lintText(text, null, opts)
+  var result
+  try {
+    result = this.lintTextSync(text, opts)
+  } catch (err) {
+    return process.nextTick(cb, err)
+  }
+  process.nextTick(cb, null, result)
 }
 
 /**

--- a/test/api.js
+++ b/test/api.js
@@ -20,9 +20,19 @@ test('api: lintFiles', function (t) {
 })
 
 test('api: lintText', function (t) {
+  t.plan(3)
+  var standard = getStandard()
+  standard.lintText('console.log("hi there")\n', function (err, result) {
+    t.error(err, 'no error while linting')
+    t.equal(typeof result, 'object', 'result is an object')
+    t.equal(result.errorCount, 1, 'should have used single quotes')
+  })
+})
+
+test('api: lintTextSync', function (t) {
   t.plan(2)
   var standard = getStandard()
-  var result = standard.lintText('console.log("hi there")\n')
+  var result = standard.lintTextSync('console.log("hi there")\n')
   t.equal(typeof result, 'object', 'result is an object')
   t.equal(result.errorCount, 1, 'should have used single quotes')
 })


### PR DESCRIPTION
Fixes: https://github.com/feross/standard/issues/807

- BREAKING: rename the synchronous `lintText` method to `lintTextSync`
- Add an asyncronous `lintText` method (that just calls `lintTextSync`
internally)

This effectively undoes the breaking change introduced in 6.0.0, making it safe to upgrade from `standard-engine` 5.x to 7.x without introducing any breaking changes.

But we also keep the new option to lint source text synchronously, just under a new `lintTextSync()` method. This is better than overloading `lintText` to behave differently depending on whether a callback is passed in or not, IMO.

Related: https://github.com/Flet/standard-engine/issues/156