### PR TITLE
Add reference to standard-engine atom plugin

### DIFF
--- a/README.md
+++ b/README.md
@@ -80,6 +80,18 @@ Additionally an optional `parseOpts()` function can be provided. See below for d
 ```
 Take a look at [eslint-config-standard](https://github.com/feross/eslint-config-standard) as an example, or if you want to extend/mutate `standard`, see [eslint-config-semistandard](https://github.com/flet/eslint-config-semistandard).
 
+## Editor Integrations
+
+### Atom
+
+[linter-js-standard-engine][atom-plugin] is an Atom plugin that supports some of
+the more popular standard-engine implementations out of the box. It detects them
+by scanning through the dependencies of the project that you are editing.
+You can use it with any other implementation through configuration in the
+projects `package.json` file.
+
+[atom-plugin]: https://github.com/gustavnikolaj/linter-js-standard-engine
+
 ## Engine Features
 
 ### Ignoring Files


### PR DESCRIPTION
As proposed in #162 

I was not quite sure with how to present it, as there is no prior art to draw inspiration from. I have tried to keep it concise and to the point. :-)

----

> I see that you don't have any editor specific integrations listed, which makes sense as this project is not targeting "end-users", but I thought that it might be useful to add a note here for any other people that maintain big or small standard-engine linters. Either just through this issue, or maybe even as a note in the README file. I would love to send a PR if it's anything you'd be interested in. :-)
