### PR TITLE
lintText/lintTextSync should not touch filesystem

### DIFF
--- a/README.md
+++ b/README.md
@@ -234,7 +234,7 @@ module.exports = {
   eslintConfig: {
     configFile: path.join(__dirname, 'eslintrc.json')
   },
-  parseOpts (opts, packageOpts, rootDir) {
+  parseOpts: function (opts, packageOpts, rootDir) {
     // provide implementation here, then return the opts object (or a new one)
     return opts
   }


### PR DESCRIPTION
Fixes https://github.com/feross/standard/issues/904

Change standard-engine so that lintText/lintTextSync doesn't take into
account the package.json settings. lintText should not behave
differently depending on the current working directory.